### PR TITLE
feat(ui): 添加卡片背景色选择功能

### DIFF
--- a/src/components/widget/DisplaySettings.svelte
+++ b/src/components/widget/DisplaySettings.svelte
@@ -2,17 +2,37 @@
 import I18nKey from "@i18n/i18nKey";
 import { i18n } from "@i18n/translation";
 import Icon from "@iconify/svelte";
-import { getDefaultHue, getHue, setHue } from "@utils/setting-utils";
+import {
+	getDefaultHue,
+	getHue,
+	setHue,
+	getCardBgType,
+	setCardBgType,
+} from "@utils/setting-utils";
 
 let hue = getHue();
 const defaultHue = getDefaultHue();
+
+// 卡片背景色类型：0 表示纯白色，1 表示主题色影响
+let cardBgType = getCardBgType();
 
 function resetHue() {
 	hue = getDefaultHue();
 }
 
+function switchCardBgType(type: number) {
+	cardBgType = type;
+}
+
 $: if (hue || hue === 0) {
 	setHue(hue);
+}
+
+$: if (
+	typeof cardBgType === "number" &&
+	(cardBgType === 0 || cardBgType === 1)
+) {
+	setCardBgType(cardBgType);
 }
 </script>
 
@@ -40,6 +60,25 @@ $: if (hue || hue === 0) {
     <div class="w-full h-6 px-1 bg-[oklch(0.80_0.10_0)] dark:bg-[oklch(0.70_0.10_0)] rounded select-none">
         <input aria-label={i18n(I18nKey.themeColor)} type="range" min="0" max="360" bind:value={hue}
                class="slider" id="colorSlider" step="5" style="width: 100%">
+    </div>
+
+    <!-- 卡片背景色标题区块 -->
+    <div class="flex gap-2 font-bold text-lg text-neutral-900 dark:text-neutral-100 transition relative ml-3 mt-4
+        before:w-1 before:h-4 before:rounded-md before:bg-[var(--primary)]
+        before:absolute before:-left-3 before:top-[0.33rem]">
+        {i18n(I18nKey.cardBackgroundColor)}
+    </div>
+
+    <!-- 卡片背景色选择器 -->
+    <div class="radio-inputs mt-3">
+        <label class="radio">
+            <input type="radio" name="card-bg-type" value="0" checked={cardBgType === 0} on:change={() => switchCardBgType(0)}>
+            <span class="name">{i18n(I18nKey.cardBackgroundSolid)}</span>
+        </label>
+        <label class="radio">
+            <input type="radio" name="card-bg-type" value="1" checked={cardBgType === 1} on:change={() => switchCardBgType(1)}>
+            <span class="name">{i18n(I18nKey.cardBackgroundGradient)}</span>
+        </label>
     </div>
 </div>
 
@@ -89,5 +128,48 @@ $: if (hue || hue === 0) {
             background rgba(255, 255, 255, 0.8)
           &:active
             background rgba(255, 255, 255, 0.6)
+
+    /* 卡片背景色选择器样式 */
+    .radio-inputs
+      position relative
+      display flex
+      flex-wrap wrap
+      border-radius var(--radius-large)
+      background-color var(--btn-regular-bg)
+      box-sizing border-box
+      padding 0.25rem
+      width 100%
+      font-size 14px
+      margin-top 0.75rem
+
+    .radio-inputs .radio
+      flex 1 1 auto
+      text-align center
+
+    .radio-inputs .radio input
+      display none
+
+    .radio-inputs .radio .name
+      display flex
+      cursor pointer
+      align-items center
+      justify-content center
+      border-radius calc(var(--radius-large) - 0.25rem)
+      border none
+      padding 0.5rem 0
+      color var(--btn-content)
+      transition all 0.15s ease-in-out
+      font-weight 400
+
+    .radio-inputs .radio input:checked + .name
+      background-color var(--primary)
+      color white
+      font-weight 500
+
+    .radio-inputs .radio:hover .name
+      background-color var(--btn-plain-bg-hover)
+
+    .radio-inputs .radio input:checked + .name
+      position relative
 
 </style>

--- a/src/i18n/i18nKey.ts
+++ b/src/i18n/i18nKey.ts
@@ -22,6 +22,9 @@ enum I18nKey {
 	postsCount = "postsCount",
 
 	themeColor = "themeColor",
+	cardBackgroundColor = "cardBackgroundColor",
+	cardBackgroundSolid = "cardBackgroundSolid",
+	cardBackgroundGradient = "cardBackgroundGradient",
 
 	lightMode = "lightMode",
 	darkMode = "darkMode",

--- a/src/i18n/languages/en.ts
+++ b/src/i18n/languages/en.ts
@@ -25,6 +25,9 @@ export const en: Translation = {
 	[Key.postsCount]: "posts",
 
 	[Key.themeColor]: "Theme Color",
+	[Key.cardBackgroundColor]: "Card Background Color",
+	[Key.cardBackgroundSolid]: "White",
+	[Key.cardBackgroundGradient]: "Theme Color",
 
 	[Key.lightMode]: "Light",
 	[Key.darkMode]: "Dark",

--- a/src/i18n/languages/ja.ts
+++ b/src/i18n/languages/ja.ts
@@ -25,6 +25,9 @@ export const ja: Translation = {
 	[Key.postsCount]: "件の投稿",
 
 	[Key.themeColor]: "テーマカラー",
+	[Key.cardBackgroundColor]: "カード背景色",
+	[Key.cardBackgroundSolid]: "真っ白",
+	[Key.cardBackgroundGradient]: "テーマカラー",
 
 	[Key.lightMode]: "ライト",
 	[Key.darkMode]: "ダーク",

--- a/src/i18n/languages/zh_CN.ts
+++ b/src/i18n/languages/zh_CN.ts
@@ -25,6 +25,9 @@ export const zh_CN: Translation = {
 	[Key.postsCount]: "篇文章",
 
 	[Key.themeColor]: "主题色",
+	[Key.cardBackgroundColor]: "卡片背景色",
+	[Key.cardBackgroundSolid]: "纯白色",
+	[Key.cardBackgroundGradient]: "主题色",
 
 	[Key.lightMode]: "亮色",
 	[Key.darkMode]: "暗色",

--- a/src/i18n/languages/zh_TW.ts
+++ b/src/i18n/languages/zh_TW.ts
@@ -25,6 +25,9 @@ export const zh_TW: Translation = {
 	[Key.postsCount]: "篇文章",
 
 	[Key.themeColor]: "主題色",
+	[Key.cardBackgroundColor]: "卡片背景色",
+	[Key.cardBackgroundSolid]: "純白色",
+	[Key.cardBackgroundGradient]: "主題色",
 
 	[Key.lightMode]: "亮色",
 	[Key.darkMode]: "暗色",

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -132,6 +132,15 @@ const bannerOffset =
 			const hue = localStorage.getItem('hue') || configHue;
 			document.documentElement.style.setProperty('--hue', hue);
 
+			// Load the card background type from local storage
+			const cardBgType = localStorage.getItem('cardBgType') || '0';
+			const bgType = parseInt(cardBgType, 10);
+			if (bgType === 0) {
+				document.documentElement.style.setProperty('--card-bg', 'var(--card-bg-original)');
+			} else if (bgType === 1) {
+				document.documentElement.style.setProperty('--card-bg', 'var(--card-bg-themed)');
+			}
+
 			// calculate the --banner-height-extend, which needs to be a multiple of 4 to avoid blurry text
 			let offset = Math.floor(window.innerHeight * (BANNER_HEIGHT_EXTEND / 100));
 			offset = offset - offset % 4;

--- a/src/styles/variables.styl
+++ b/src/styles/variables.styl
@@ -25,7 +25,9 @@ define(vars)
 define({
   --primary: oklch(0.70 0.14 var(--hue)) oklch(0.75 0.14 var(--hue))
   --page-bg: oklch(0.95 0.01 var(--hue)) oklch(0.16 0.014 var(--hue))
-  --card-bg: oklch(0.99 0.01 var(--hue)) oklch(0.23 0.015 var(--hue))
+  --card-bg-original: white oklch(0.23 0.015 var(--hue))
+  --card-bg-themed: oklch(0.99 0.01 var(--hue)) oklch(0.23 0.015 var(--hue))
+  --card-bg: var(--card-bg-original)
 
   --btn-content: oklch(0.55 0.12 var(--hue)) oklch(0.75 0.1 var(--hue))
 

--- a/src/utils/setting-utils.ts
+++ b/src/utils/setting-utils.ts
@@ -59,3 +59,26 @@ export function setTheme(theme: LIGHT_DARK_MODE): void {
 export function getStoredTheme(): LIGHT_DARK_MODE {
 	return (localStorage.getItem("theme") as LIGHT_DARK_MODE) || DEFAULT_THEME;
 }
+
+// 卡片背景色
+export function getDefaultCardBgType(): number {
+	return 0; // 默认纯白色
+}
+
+export function getCardBgType(): number {
+	const stored = localStorage.getItem("cardBgType");
+	return stored !== null ? Number.parseInt(stored, 10) : getDefaultCardBgType();
+}
+
+export function setCardBgType(type: number): void {
+	localStorage.setItem("cardBgType", String(type));
+	const r = document.querySelector(":root") as HTMLElement;
+	if (!r) {
+		return;
+	}
+	if (type === 0) {
+		r.style.setProperty("--card-bg", "var(--card-bg-original)");
+	} else if (type === 1) {
+		r.style.setProperty("--card-bg", "var(--card-bg-themed)");
+	}
+}


### PR DESCRIPTION
Close #38

- 为显示设置添加卡片背景色选择功能，允许用户在纯白色和主题色背景之间切换
- 包括新的UI选择组件、多语言国际化支持、CSS变量样式定义、持久化工具函数，以及布局集成实现动态应用